### PR TITLE
fix header embedder request to openai-compatible api

### DIFF
--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -199,6 +199,9 @@ export class OpenAICompatibleAIProvider implements AIProvider {
 				const { json } = await requestUrl({
 					url: `${this.url.replace(/\/+$/i, "")}/v1/embeddings`,
 					method: "POST",
+					headers: {
+						"Content-Type": "application/json"
+					},
 					body: JSON.stringify({
 						input: [text],
 						model: this.embeddingModel,


### PR DESCRIPTION
when using LM studio I was getting an error for missing 'input' field I fixed it by adding the header in the code